### PR TITLE
Update AGP version to 8.10.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.2"
+agp = "8.10.0"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"


### PR DESCRIPTION
This commit updates the Android Gradle Plugin (AGP) version from 8.9.2 to 8.10.0 in the `gradle/libs.versions.toml` file.