### PR TITLE
Update AGP version in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0"
+agp = "8.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"


### PR DESCRIPTION
The Android Gradle Plugin (AGP) version has been updated from 8.10.0 to 8.10.1 in the `gradle/libs.versions.toml` file.